### PR TITLE
Skip wireless role without ending play

### DIFF
--- a/roles/wireless/tasks/main.yml
+++ b/roles/wireless/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: Skip wireless if disabled
-  ansible.builtin.meta: end_play
-  when: not (wireless.enabled | default(false))
-
 - name: Deploy minimal wireless config
   ansible.builtin.template:
     src: wireless.j2
@@ -11,3 +7,4 @@
     group: root
     mode: '0644'
   notify: Reload wireless
+  when: wireless.enabled | default(false)


### PR DESCRIPTION
## Summary
- remove meta end_play from wireless role
- add conditional to template so role is skipped when wireless.disabled

## Testing
- `ansible-lint --offline roles/wireless`

------
https://chatgpt.com/codex/tasks/task_e_689e08e13c58832b8bbbe50a5303d581