### PR TITLE
Use authorized_key module for SSH keys

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
   - name: community.general
+  - name: ansible.posix

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -10,10 +10,9 @@
 
 - name: Ensure authorized SSH keys
   when: system.authorized_keys | length > 0
-  ansible.builtin.lineinfile:
+  ansible.posix.authorized_key:
     path: /etc/dropbear/authorized_keys
-    create: true
-    line: "{{ item }}"
+    key: "{{ item }}"
     owner: root
     group: root
     mode: '0600'


### PR DESCRIPTION
## Summary
- use ansible.posix.authorized_key to manage Dropbear authorized_keys
- add ansible.posix to collection requirements

## Testing
- `ansible-lint --offline roles/base/tasks/main.yml` *(missing `ansible.posix` collection, install attempt failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e0c2ab8ec832babdfc55d90d961e4