### PR TITLE
Verify imagebuilder tarball via sha256

### DIFF
--- a/imagebuilder/build.sh
+++ b/imagebuilder/build.sh
@@ -9,6 +9,14 @@ PACKAGES="python3-light openssh-sftp-server ca-bundle ca-certificates"
 EXTRA_OPTS=""
 WORKDIR="$(pwd)"
 
+# Ensure required tools are available
+for cmd in curl tar sha256sum; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: required tool '$cmd' not found." >&2
+    exit 1
+  fi
+done
+
 usage() {
   cat <<EOF
 Usage: $0 --release <X.Y.Z> --target <target> --subtarget <sub> --profile <profile> [--packages "pkg1 pkg2"] [--extra 'KEY=VALUE']
@@ -32,9 +40,15 @@ done
 
 IB_URL="https://downloads.openwrt.org/releases/${RELEASE}/targets/${TARGET}/${SUBTARGET}/openwrt-imagebuilder-${RELEASE}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.xz"
 TAR="openwrt-imagebuilder-${RELEASE}-${TARGET}-${SUBTARGET}.Linux-x86_64.tar.xz"
+SHA256_URL="${IB_URL}.sha256"
+SHA256_FILE="${TAR}.sha256"
 
 echo "[*] Téléchargement ImageBuilder: ${IB_URL}"
 curl -fL -o "${TAR}" "${IB_URL}"
+echo "[*] Téléchargement fichier SHA256: ${SHA256_URL}"
+curl -fL -o "${SHA256_FILE}" "${SHA256_URL}"
+echo "[*] Vérification de l'archive"
+sha256sum -c "${SHA256_FILE}"
 tar -xf "${TAR}"
 cd "openwrt-imagebuilder-${RELEASE}-${TARGET}-${SUBTARGET}.Linux-x86_64"
 


### PR DESCRIPTION
## Summary
- download ImageBuilder SHA256 file and verify tarball
- ensure curl, tar and sha256sum are installed

## Testing
- `bash -n imagebuilder/build.sh`
- `./imagebuilder/build.sh -h`


------
https://chatgpt.com/codex/tasks/task_e_689e12c52110832b8bba51189d32d396