### PR TITLE
ci: add shellcheck validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: ShellCheck build script
+        run: shellcheck imagebuilder/build.sh
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/imagebuilder/build.sh
+++ b/imagebuilder/build.sh
@@ -54,6 +54,7 @@ cd "openwrt-imagebuilder-${RELEASE}-${TARGET}-${SUBTARGET}.Linux-x86_64"
 
 mkdir -p "${WORKDIR}/files"
 echo "[*] Build image profile=${PROFILE} packages='${PACKAGES}'"
+# shellcheck disable=SC2086
 make image PROFILE="${PROFILE}" PACKAGES="${PACKAGES}" FILES="${WORKDIR}/files" ${EXTRA_OPTS}
 
 echo "[*] Images construites dans: $(pwd)/bin/targets/${TARGET}/${SUBTARGET}"


### PR DESCRIPTION
## Summary
- install ShellCheck in CI and run `shellcheck imagebuilder/build.sh`
- silence SC2086 warning in build script to allow ShellCheck to pass

## Testing
- `shellcheck imagebuilder/build.sh`


------
https://chatgpt.com/codex/tasks/task_e_689e13b0ebd4832b9a3b78f7488f6c68