### PR TITLE
Add role metadata

### DIFF
--- a/roles/base/meta/main.yml
+++ b/roles/base/meta/main.yml
@@ -1,0 +1,7 @@
+---
+galaxy_info:
+  author: Franck Laplagne
+  description: Base system configuration
+  license: MIT
+  min_ansible_version: '2.14'
+dependencies: []

--- a/roles/dnsdhcp/meta/main.yml
+++ b/roles/dnsdhcp/meta/main.yml
@@ -1,0 +1,7 @@
+---
+galaxy_info:
+  author: Franck Laplagne
+  description: DNS and DHCP configuration
+  license: MIT
+  min_ansible_version: '2.14'
+dependencies: []

--- a/roles/firewall/meta/main.yml
+++ b/roles/firewall/meta/main.yml
@@ -1,0 +1,7 @@
+---
+galaxy_info:
+  author: Franck Laplagne
+  description: Firewall configuration
+  license: MIT
+  min_ansible_version: '2.14'
+dependencies: []

--- a/roles/network/meta/main.yml
+++ b/roles/network/meta/main.yml
@@ -1,0 +1,7 @@
+---
+galaxy_info:
+  author: Franck Laplagne
+  description: Network interfaces configuration
+  license: MIT
+  min_ansible_version: '2.14'
+dependencies: []

--- a/roles/packages/meta/main.yml
+++ b/roles/packages/meta/main.yml
@@ -1,0 +1,7 @@
+---
+galaxy_info:
+  author: Franck Laplagne
+  description: Install baseline packages
+  license: MIT
+  min_ansible_version: '2.14'
+dependencies: []

--- a/roles/wireless/meta/main.yml
+++ b/roles/wireless/meta/main.yml
@@ -1,0 +1,7 @@
+---
+galaxy_info:
+  author: Franck Laplagne
+  description: Wireless configuration
+  license: MIT
+  min_ansible_version: '2.14'
+dependencies: []


### PR DESCRIPTION
## Summary
- add `meta/main.yml` for every role with Galaxy info and dependencies

## Testing
- `ansible-lint` *(fails: HTTPSConnection.__init__() got an unexpected keyword argument 'cert_file')*
- `ansible-playbook --syntax-check playbooks/bootstrap.yml playbooks/site.yml` *(fails: couldn't resolve module/action 'community.general.opkg')*


------
https://chatgpt.com/codex/tasks/task_e_689e1a0b1244832bb03696a42c63901f