### PR TITLE
Clean up ImageBuilder artifacts after build

### DIFF
--- a/imagebuilder/README.md
+++ b/imagebuilder/README.md
@@ -21,3 +21,5 @@ cd imagebuilder
 Tu peux personnaliser :
 - `PACKAGES` : liste d'addons.
 - `files/` : overlay (bannières, uci-defaults, clés SSH…).
+
+Le script télécharge et extrait temporairement l'ImageBuilder puis supprime automatiquement l'archive et le dossier à la fin de l'exécution (ou en cas d'erreur). Les images générées sont conservées dans `imagebuilder/bin/targets/...`.


### PR DESCRIPTION
## Summary
- remove downloaded ImageBuilder tarball and directory via `trap`
- document cleanup behaviour in README

## Testing
- `shellcheck imagebuilder/build.sh`
- `cd imagebuilder && ./build.sh --help`


------
https://chatgpt.com/codex/tasks/task_e_689e1e496408832b96c573393beeff47