### PR TITLE
Add fail2ban security role

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ playbooks/
 roles/
   base/                     # Configuration de base
   packages/                 # Paquets supplémentaires
+  fail2ban/                 # Protection fail2ban
   network/                  # Interfaces, VLANs, firewall
   dnsdhcp/                  # DNS et DHCP
   wireless/                 # WiFi
@@ -81,11 +82,25 @@ roles/
 Chaque rôle inclut des variables préfixées dans `defaults/main.yml` :
 
 - **base** (`base_system`) : nom d'hôte `openwrt`, fuseau `UTC`, serveurs NTP standards.
-- **packages** (`packages_opkg_packages`) : openssh-sftp-server, ca-bundle, ca-certificates, luci-ssl, htop.
+- **packages** (`packages_opkg_packages`) : openssh-sftp-server, ca-bundle, ca-certificates, luci-ssl, htop, fail2ban.
+- **fail2ban** (`fail2ban_enabled`, `fail2ban_jails`) : service activé avec jails SSH et LuCI.
 - **network** (`network_config`) : LAN `192.168.1.1/24` sur `br-lan`, WAN DHCP sur `wan`, ports `lan1..lan4`. `network_wireguard.enabled` et `network_vlans.enabled` désactivés.
 - **dnsdhcp** (`dnsdhcp_config.lan_dhcp`) : début `100`, limite `150`, bail `12h`, domaine `lan`.
 - **wireless** (`wireless_config`) : désactivé par défaut, SSID `MyWiFi`, chiffrement `psk2`.
 - **firewall** : aucune zone supplémentaire ; s'appuie sur `firewall_wireguard`/`firewall_vlans`.
+
+### Exemple fail2ban
+
+```yaml
+fail2ban_enabled: true
+fail2ban_jails:
+  - name: ssh
+    port: ssh
+    logpath: /var/log/auth.log
+  - name: luci
+    port: http,https
+    logpath: /var/log/uhttpd-access.log
+```
 
 ## Exemple VLAN / IoT
 Activer un VLAN isolé pour les objets connectés :

--- a/group_vars/openwrt.yml
+++ b/group_vars/openwrt.yml
@@ -16,6 +16,7 @@ packages_opkg_packages:
   - ca-certificates
   - luci-ssl
   - htop
+  - fail2ban
 
 network_config: &network_defaults
   lan:

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -5,6 +5,7 @@
   roles:
     - base
     - packages
+    - fail2ban
     - network
     - firewall
     - dnsdhcp

--- a/roles/fail2ban/defaults/main.yml
+++ b/roles/fail2ban/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+fail2ban_enabled: true
+fail2ban_jails:
+  - name: ssh
+    enabled: true
+    port: ssh
+    logpath: /var/log/auth.log
+    maxretry: 5
+  - name: luci
+    enabled: true
+    port: http,https
+    logpath: /var/log/uhttpd-access.log
+    maxretry: 3

--- a/roles/fail2ban/handlers/main.yml
+++ b/roles/fail2ban/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Restart fail2ban
+  ansible.builtin.command: /etc/init.d/fail2ban restart
+  changed_when: false

--- a/roles/fail2ban/meta/main.yml
+++ b/roles/fail2ban/meta/main.yml
@@ -1,0 +1,7 @@
+---
+galaxy_info:
+  author: Franck Laplagne
+  description: Configure fail2ban
+  license: MIT
+  min_ansible_version: '2.14'
+dependencies: []

--- a/roles/fail2ban/tasks/main.yml
+++ b/roles/fail2ban/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: Install fail2ban
+  community.general.opkg:
+    name: fail2ban
+    state: present
+  when: fail2ban_enabled
+
+- name: Deploy jail configuration
+  ansible.builtin.template:
+    src: jail.local.j2
+    dest: /etc/fail2ban/jail.local
+  when: fail2ban_enabled
+  notify: Restart fail2ban
+
+- name: Enable fail2ban service
+  ansible.builtin.command: /etc/init.d/fail2ban enable
+  when: fail2ban_enabled
+  changed_when: false
+
+- name: Start fail2ban service
+  ansible.builtin.command: /etc/init.d/fail2ban start
+  when: fail2ban_enabled
+  changed_when: false

--- a/roles/fail2ban/tasks/main.yml
+++ b/roles/fail2ban/tasks/main.yml
@@ -9,6 +9,9 @@
   ansible.builtin.template:
     src: jail.local.j2
     dest: /etc/fail2ban/jail.local
+    owner: root
+    group: root
+    mode: '0644'
   when: fail2ban_enabled
   notify: Restart fail2ban
 

--- a/roles/fail2ban/templates/jail.local.j2
+++ b/roles/fail2ban/templates/jail.local.j2
@@ -1,0 +1,9 @@
+# Managed by Ansible
+{% for jail in fail2ban_jails %}
+[{{ jail.name }}]
+enabled = {{ jail.enabled | default(true) | ternary('true','false') }}
+port    = {{ jail.port | default('ssh') }}
+logpath = {{ jail.logpath | default('/var/log/auth.log') }}
+maxretry = {{ jail.maxretry | default(5) }}
+
+{% endfor %}

--- a/roles/packages/defaults/main.yml
+++ b/roles/packages/defaults/main.yml
@@ -5,3 +5,4 @@ packages_opkg_packages:
   - ca-certificates
   - luci-ssl
   - htop
+  - fail2ban


### PR DESCRIPTION
## Summary
- add fail2ban package to default list
- introduce fail2ban role with SSH and LuCI jails
- document fail2ban variables and usage

## Testing
- `ansible-lint` *(failed: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/' - Tunnel connection failed: 403 Forbidden)*
- `ansible-playbook --syntax-check playbooks/bootstrap.yml`
- `ansible-playbook --syntax-check playbooks/site.yml` *(failed: couldn't resolve module/action 'community.general.opkg')*


------
https://chatgpt.com/codex/tasks/task_e_689e20cd8284832bbe25f6f7ecb5fd54