### PR TITLE
Add backup role for router configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ roles/
   base/                     # Configuration de base
   packages/                 # Paquets supplémentaires
   logging/                 # Redirection des logs
+  backup/                  # Sauvegarde de la configuration
   fail2ban/                 # Protection fail2ban
   ha/                       # Haute disponibilité VRRP
   network/                  # Interfaces, VLANs, firewall
@@ -87,6 +88,7 @@ Chaque rôle inclut des variables préfixées dans `defaults/main.yml` :
 - **base** (`base_system`) : nom d'hôte `openwrt`, fuseau `UTC`, serveurs NTP standards.
 - **packages** (`packages_opkg_packages`) : openssh-sftp-server, ca-bundle, ca-certificates, luci-ssl, htop, rsyslog, fail2ban, bird2, keepalived.
 - **logging** (`logging_enabled`, `logging_server`, `logging_facility`) : désactivé par défaut, redirige les logs vers `logging_server` avec la facility `logging_facility`
+- **backup** (`backup_enabled`, `backup_destination`, `backup_schedule`) : archive `/etc/config` et fichiers critiques vers `backup_destination` selon `backup_schedule`.
 - **fail2ban** (`fail2ban_enabled`, `fail2ban_jails`) : service activé avec jails SSH et LuCI.
 - **ha** (`ha_enabled`, `ha_vrrp_instances`) : désactivé par défaut, déploie keepalived et les instances VRRP.
 - **network** (`network_config`) : LAN `192.168.1.1/24` sur `br-lan`, WAN DHCP sur `wan`, ports `lan1..lan4`. `network_wireguard.enabled` et `network_vlans.enabled` désactivés.
@@ -204,6 +206,13 @@ cd imagebuilder
 Le workflow GitHub Actions `.github/workflows/ci.yml` vérifie :
 - `ansible-lint`
 - `ansible-playbook --syntax-check` sur `playbooks/bootstrap.yml` et `playbooks/site.yml`
+
+### Restauration depuis une archive
+
+```bash
+scp backup.tgz root@routeur:/tmp/
+ssh root@routeur "tar xzf /tmp/backup.tgz -C /"
+```
 
 ## Notes
 - **Ports DSA** : ajustez `network_config.bridge_ports` et `network_config.wan.device` selon votre matériel (`lan1..lan4`, `wan`, etc.).

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -7,6 +7,7 @@
     - packages
     - monitoring
     - logging
+    - backup
     - fail2ban
     - ha
     - network

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+backup_enabled: true
+backup_destination: "user@backup-server:/backups"
+backup_schedule: "0 3 * * *"

--- a/roles/backup/handlers/main.yml
+++ b/roles/backup/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Run backup
+  ansible.builtin.command: /usr/local/bin/backup.sh
+  when: backup_enabled
+  changed_when: false

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Deploy backup script
+  ansible.builtin.template:
+    src: backup.sh.j2
+    dest: /usr/local/bin/backup.sh
+    owner: root
+    group: root
+    mode: '0755'
+  when: backup_enabled
+  notify: Run backup
+
+- name: Schedule backup
+  ansible.builtin.cron:
+    name: "Config backup"
+    minute: "{{ backup_schedule.split()[0] }}"
+    hour: "{{ backup_schedule.split()[1] }}"
+    day: "{{ backup_schedule.split()[2] }}"
+    month: "{{ backup_schedule.split()[3] }}"
+    weekday: "{{ backup_schedule.split()[4] }}"
+    job: "/usr/local/bin/backup.sh"
+  when: backup_enabled

--- a/roles/backup/templates/backup.sh.j2
+++ b/roles/backup/templates/backup.sh.j2
@@ -1,0 +1,3 @@
+#!/bin/sh
+tar czf /tmp/config_backup.tgz /etc/config /etc/passwd /etc/group /etc/shadow
+scp /tmp/config_backup.tgz {{ backup_destination }}


### PR DESCRIPTION
## Summary
- add backup role with cron-driven tar + scp script
- include backup role in main playbook
- document backup defaults and restore steps

## Testing
- `ansible-lint` *(fails: Unknown error when attempting to call Galaxy at 'https://galaxy.ansible.com/api/': <urlopen error Tunnel connection failed: 403 Forbidden>)*
- `ansible-playbook --syntax-check playbooks/bootstrap.yml`
- `ansible-playbook --syntax-check playbooks/site.yml` *(fails: couldn't resolve module/action 'community.general.opkg')*

------
https://chatgpt.com/codex/tasks/task_e_689e2c4e079c832b91cfc98189a25052