### PR TITLE
feat: enable sops for wireguard secrets

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,8 @@
 skip_list:
   - command-instead-of-module    # 'raw' is expected for OpenWrt bootstrap
   - unnamed-task
+exclude_paths:
+  - group_vars/*.sops.yaml
 warn_list:
   - fqcn-builtins
   - jinja[spacing]

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 *.swp
 *.swo
 *.DS_Store
+agekey.txt

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+  - path_regex: group_vars/.*\.sops\.yaml$
+    age: age1pddd9tpmse2rjaxf33zwzzfvq4elkzz3svukgvk07hchs8kyqags8nl09n

--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ scp backup.tgz root@routeur:/tmp/
 ssh root@routeur "tar xzf /tmp/backup.tgz -C /"
 ```
 
+## Secrets chiffrés avec SOPS
+
+Les secrets (ex. clés WireGuard) résident dans `group_vars/*.sops.yaml` et sont chiffrés avec [SOPS](https://github.com/getsops/sops) et `age`.
+Pour les éditer, exporter la clé privée et utiliser `sops` :
+
+```bash
+export SOPS_AGE_KEY_FILE=agekey.txt
+sops group_vars/wireguard-secrets.sops.yaml
+```
+
 ## Notes
 - **Ports DSA** : ajustez `network_config.bridge_ports` et `network_config.wan.device` selon votre matériel (`lan1..lan4`, `wan`, etc.).
 - **WiFi** : le rôle `wireless` propose un template minimaliste désactivé par défaut (`wireless_config`).

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -8,6 +8,7 @@ remote_tmp = /tmp/.ansible-${USER}
 interpreter_python = auto
 retry_files_enabled = False
 stdout_callback = yaml
+vars_plugins_enabled = host_group_vars,community.sops
 
 [ssh_connection]
 pipelining = True

--- a/group_vars/wireguard-secrets.sops.yaml
+++ b/group_vars/wireguard-secrets.sops.yaml
@@ -1,0 +1,22 @@
+wireguard_private_key: ENC[AES256_GCM,data:75ZCmomHTeXt+1kiWocYczIYgLfEG9c=,iv:ycgogw3qWNr3Rwe5YeINssA//e84cNRgQLqLbivXGt4=,tag:D9BoGn4szb6uM0QbSyhfhw==,type:str]
+wireguard_public_key: ENC[AES256_GCM,data:eG6jb5pZY/oYX+s0CWPqwnX97MEMYg==,iv:tmcxEmyruKtEr1VKXnXy2ZZrqDckV2DlgXc3cMZKuk8=,tag:zkS6h/dIQAyBg/DpEs4erw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1pddd9tpmse2rjaxf33zwzzfvq4elkzz3svukgvk07hchs8kyqags8nl09n
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXdmQ4YWtlTTFEWGdYMld6
+            Qm8wN2NWOWU2eXVTbm42dVY4cHpNNlcyQkZBCkJGLzMzejlWZXRaQkJGTjJTQ2Zl
+            d0lnbVNTRzhVa0RnZlRPbmlSeGtsSlEKLS0tIFR5Y0NuRUZaTlcwdVdUd1ZKa25m
+            TDhWeFo1UjJPaWtkU2kwaDd4UkcxOTgKes6nDjrOjZGCNa0I3RWi0jmaIWIzagoB
+            MFHNwshWn28m6u/sGi4kf0ukDLtxJQrKbwXOh9THeg3+8+zU7S+j7A==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-08-18T18:09:22Z"
+    mac: ENC[AES256_GCM,data:rkXYI9/57QXijCSU94R2T5kgC4k8wiHhh7jZ1vn708Q2/D5VCZk8jP0ww459FkXDQ5HnKqkf9mIIhaFYoEareuALV8k9+pGuxT2ynD51K42oJNRt4XwnknT3RSm+bH38EefNtTuGoaqHGQ6TjQzhtfAgq3+/eP4K+TrOlNyoFbs=,iv:HkH1HGRCztc0xT7qgGkBgvgoqvNQwV1pKl+FEZlksEY=,tag:1IH9fzWsKOwnQ3H8ZrADhg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.9.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
   - name: community.general
+  - name: community.sops


### PR DESCRIPTION
## Summary
- enable community.sops vars plugin
- manage WireGuard keys with SOPS

## Testing
- [ ] `ansible-galaxy collection install -r requirements.yml --force` (403 Forbidden)
- [x] `ANSIBLE_CONFIG=ansible.cfg SOPS_AGE_KEY_FILE=agekey.txt ansible-lint`
- [x] `ANSIBLE_CONFIG=ansible.cfg SOPS_AGE_KEY_FILE=agekey.txt ansible-playbook --syntax-check playbooks/bootstrap.yml`
- [x] `ANSIBLE_CONFIG=ansible.cfg SOPS_AGE_KEY_FILE=agekey.txt ansible-playbook --syntax-check playbooks/site.yml`

## Checklist
- [x] Documentation updated
- [ ] Ready for review

## Approvals
- [ ] @maintainer

------
https://chatgpt.com/codex/tasks/task_e_68a36b5bedbc832b9ec08b0f2a985107